### PR TITLE
feat(added): add custom authorizer for import method

### DIFF
--- a/bin/learn-aws-be.ts
+++ b/bin/learn-aws-be.ts
@@ -3,8 +3,10 @@ import "source-map-support/register";
 import * as cdk from "aws-cdk-lib";
 import { ProductServiceStack } from "../lib/product-service-stack";
 import { ImportServiceStack } from "../lib/import-service-stack";
+import { AuthorizationServiceStack } from "../lib/authorization-service-stack";
 
 const app = new cdk.App();
 
+new AuthorizationServiceStack(app, "AuthorizationServiceStack", {});
 new ImportServiceStack(app, "ImportServiceStack", {});
 new ProductServiceStack(app, "LambdasStack", {});

--- a/lambda/authorization/basicAuthorizer/index.ts
+++ b/lambda/authorization/basicAuthorizer/index.ts
@@ -1,0 +1,49 @@
+import {
+  APIGatewayAuthorizerResult,
+  APIGatewayTokenAuthorizerEvent,
+} from "aws-lambda";
+
+const credentials = process.env.CREDENTIALS as string;
+
+export async function main(event: APIGatewayTokenAuthorizerEvent) {
+  try {
+    const token = event.authorizationToken;
+    if (token) {
+      const [, tokenValue] = token.split(" ");
+      const decodedToken = Buffer.from(tokenValue, "base64").toString("utf-8");
+
+      if (decodedToken === credentials) {
+        return createPolicy("Allow", event.methodArn);
+      } else {
+        return createPolicy("Deny", event.methodArn, 403);
+      }
+    } else {
+      return createPolicy("Deny", event.methodArn, 401);
+    }
+  } catch (e: unknown) {
+    console.log(e);
+    return Promise.reject("Unknown error");
+  }
+}
+function createPolicy(
+  effect: "Allow" | "Deny",
+  resource: string,
+  statusCode = 200,
+): APIGatewayAuthorizerResult {
+  return {
+    principalId: "user",
+    policyDocument: {
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Action: "execute-api:Invoke",
+          Effect: effect,
+          Resource: resource,
+        },
+      ],
+    },
+    context: {
+      statusCode,
+    },
+  };
+}

--- a/lib/authorization-service-stack.ts
+++ b/lib/authorization-service-stack.ts
@@ -1,0 +1,32 @@
+import * as cdk from "aws-cdk-lib";
+import { CfnOutput } from "aws-cdk-lib";
+
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as path from "path";
+
+import { Construct } from "constructs";
+
+export class AuthorizationServiceStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const basicAuthorizerFunction = new lambda.Function(
+      this,
+      "basic-authorizer-function",
+      {
+        runtime: lambda.Runtime.NODEJS_20_X,
+        memorySize: 1024,
+        timeout: cdk.Duration.seconds(5),
+        handler: "index.main",
+        code: lambda.Code.fromAsset(
+          path.join(__dirname, "../lambda/authorization/basicAuthorizer"),
+        ),
+      },
+    );
+
+    new CfnOutput(this, "basic-authorizer-function-output", {
+      value: basicAuthorizerFunction.functionArn,
+      exportName: "BasicAuthorizerFunctionArn",
+    });
+  }
+}


### PR DESCRIPTION
- [x] authorization-service is added to the repo, has correct basicAuthorizer lambda and correct CDK file
- [x] Import Service CDK file has authorizer configuration for the importProductsFile lambda. Request to the importProductsFile lambda should work only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response should be in 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided.
- [x]  Client application is updated to send "Authorization: Basic authorization_token" header on import. Client should get authorization_token value from browser [localStorage](https://developer.mozilla.org/ru/docs/Web/API/Window/localStorage)

- [x] Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the nodejs-aws-fe-main/src/index.tsx file.


https://d1qy3wei893duj.cloudfront.net/